### PR TITLE
Fixed rows and columns of artifact belt

### DIFF
--- a/src/xrGame/ui/UIActorMenuInitialize.cpp
+++ b/src/xrGame/ui/UIActorMenuInitialize.cpp
@@ -113,25 +113,36 @@ void CUIActorMenu::Construct()
 	m_pTradePartnerBagList		= UIHelper::CreateDragDropListEx(uiXml, "dragdrop_partner_bag", this);
 	m_pTradePartnerList			= UIHelper::CreateDragDropListEx(uiXml, "dragdrop_partner_trade", this);
 
-	m_belt_list_over[0] = UIHelper::CreateStatic(uiXml, "belt_list_over", this);
-	Fvector2 pos;
-	float dy = 0.f;
-	/*pos								= m_ArtefactSlotsHighlight[0]->GetWndPos();
-	dy								= uiXml.ReadAttribFlt("artefact_slot_highlight", 0, "dy", 24.0f);
-	for(u8 i=1;i<e_af_count;i++)
+	Fvector2 pos{};
+	float dx{}, dy{};
+	int cols = m_pInventoryBeltList->CellsCapacity().x;
+	int rows = m_pInventoryBeltList->CellsCapacity().y;
+	int counter = 1;
+
+	for (u8 i = 0; i < rows; ++i)
 	{
-		pos.y						+= dy;
-		m_ArtefactSlotsHighlight[i]	= UIHelper::CreateStatic(uiXml, "artefact_slot_highlight", this);
-		m_ArtefactSlotsHighlight[i]	->SetWndPos(pos);
-		m_ArtefactSlotsHighlight[i]	->Show(false);
-	}*/
-	pos = m_belt_list_over[0]->GetWndPos();
-	dy = uiXml.ReadAttribFlt("belt_list_over", 0, "dy", 10.0f);
-	for ( u8 i = 1; i < e_af_count; ++i )
-	{
+		for (u8 j = 0; j < cols; ++j)
+		{
+			if (i == 0 && j == 0)
+			{
+				m_belt_list_over[0] = UIHelper::CreateStatic(uiXml, "belt_list_over", this);
+				pos = m_belt_list_over[0]->GetWndPos();
+				dx = uiXml.ReadAttribFlt("belt_list_over", 0, "dx", 10.0f);
+				dy = uiXml.ReadAttribFlt("belt_list_over", 0, "dy", 10.0f);
+			}
+			else
+			{
+				if (j != 0)
+					pos.x += dx;
+
+				m_belt_list_over[counter] = UIHelper::CreateStatic(uiXml, "belt_list_over", this);
+				m_belt_list_over[counter]->SetWndPos(pos);
+				counter++;
+			}
+		}
+
+		pos.x = m_belt_list_over[0]->GetWndPos().x;
 		pos.y += dy;
-		m_belt_list_over[i] = UIHelper::CreateStatic(uiXml, "belt_list_over", this);
-		m_belt_list_over[i]->SetWndPos( pos );
 	}
 
 	m_ActorMoney	= UIHelper::CreateStatic(uiXml, "actor_money_static", this);

--- a/src/xrGame/ui/UIActorMenuInventory.cpp
+++ b/src/xrGame/ui/UIActorMenuInventory.cpp
@@ -1034,8 +1034,8 @@ void CUIActorMenu::UpdateOutfit()
 	}
 
 	Ivector2 afc;
-	afc.x = 1; // m_pInventoryBeltList->GetCellsCapacity().x;
-	afc.y = af_count;
+	afc.x = m_pInventoryBeltList->CellsCapacity().x;
+	afc.y = m_pInventoryBeltList->CellsCapacity().y;
 	
 	m_pInventoryBeltList->SetCellsCapacity( afc );
 	for ( u8 i = 0; i < af_count ; ++i )


### PR DESCRIPTION
Proposed changes:

- Fixed rows and columns of artifact belt

Now the `cols` and `rows` parameters in `dragdrop_belt` are working fine. The `dx` parameter has been added, which is responsible for the distance between cells along the X coordinate

Important: `rows` and `cols` must not exceed the maximum number of artifacts on the belt

Agreements:

- [x] I agree to follow this project's [__Contributing Guidelines__](https://github.com/ixray-team/.github/blob/default/CONTRIBUTING.md)
- [x] I agree to follow this project's [__Code of Conduct__](https://github.com/ixray-team/.github/blob/default/CODE_OF_CONDUCT.md)
